### PR TITLE
Implements `InternalServerError`

### DIFF
--- a/infra/database.js
+++ b/infra/database.js
@@ -10,7 +10,7 @@ async function query(queryObject) {
     console.error("Error executing query:", error);
     throw error;
   } finally {
-    await client.end();
+    await client?.end();
   }
 }
 

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,0 +1,19 @@
+export class InternalServerError extends Error {
+  constructor({ cause }) {
+    super("Um erro interno não esperado aconteceu.", {
+      cause,
+    });
+    this.name = "InternalServerError";
+    this.action = "Entre em contato com o suporte.";
+    this.statusCode = 500;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      statusCode: this.statusCode,
+    };
+  }
+}

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,32 +1,42 @@
 import database from "infra/database";
+import { InternalServerError } from "infra/errors";
 
 async function status(request, response) {
-  const updatedAt = new Date().toISOString();
+  try {
+    const updatedAt = new Date().toISOString();
 
-  const databaseVersion = (await database.query("SHOW server_version;")).rows[0]
-    .server_version;
+    const databaseVersion = (await database.query("SHOW server_version;"))
+      .rows[0].server_version;
 
-  const databaseMaxConnections = (await database.query("SHOW max_connections;"))
-    .rows[0].max_connections;
+    const databaseMaxConnections = (
+      await database.query("SHOW max_connections;")
+    ).rows[0].max_connections;
 
-  const databaseName = process.env.POSTGRES_DB;
-  const databaseUsedConnections = (
-    await database.query({
-      text: "SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1;",
-      values: [databaseName],
-    })
-  ).rows[0].count;
+    const databaseName = process.env.POSTGRES_DB;
+    const databaseUsedConnections = (
+      await database.query({
+        text: "SELECT COUNT(*)::int FROM pg_stat_activity WHERE datname = $1;",
+        values: [databaseName],
+      })
+    ).rows[0].count;
 
-  response.status(200).json({
-    updated_at: updatedAt,
-    dependencies: {
-      database: {
-        version: databaseVersion,
-        max_connections: parseInt(databaseMaxConnections),
-        opened_connections: databaseUsedConnections,
+    response.status(200).json({
+      updated_at: updatedAt,
+      dependencies: {
+        database: {
+          version: databaseVersion,
+          max_connections: parseInt(databaseMaxConnections),
+          opened_connections: databaseUsedConnections,
+        },
       },
-    },
-  });
+    });
+  } catch (error) {
+    const publicErrorObject = new InternalServerError({
+      cause: error,
+    });
+    console.error(publicErrorObject);
+    response.status(500).json(publicErrorObject);
+  }
 }
 
 export default status;


### PR DESCRIPTION
This pull request introduces improved error handling for the status API endpoint and a minor safety enhancement in the database utility. The main focus is on providing a standardized error response when unexpected internal errors occur.

**Error handling improvements:**

* Added a new `InternalServerError` class in `infra/errors.js` to standardize internal error responses, including a user-facing message, action, and status code.
* Updated the status API endpoint (`pages/api/v1/status/index.js`) to use a try-catch block; now, any unexpected errors are caught and returned as a structured JSON error response using the new `InternalServerError` class. [[1]](diffhunk://#diff-4c5456b87d0969ca5f804a5dc57d93476f0dfa7d79bb3ffe72da9260ad881858R2-R5) [[2]](diffhunk://#diff-4c5456b87d0969ca5f804a5dc57d93476f0dfa7d79bb3ffe72da9260ad881858R32-R38)

**Code robustness:**

* Modified the database utility (`infra/database.js`) to safely call `client.end()` only if the client exists, preventing potential runtime errors when closing the database connection.