### PR TITLE
Create migrator model

### DIFF
--- a/models/migrator.js
+++ b/models/migrator.js
@@ -40,7 +40,6 @@ async function runPendingMigrations() {
   }
 }
 
-
 const migrator = {
   listPendingMigrations,
   runPendingMigrations,

--- a/models/migrator.js
+++ b/models/migrator.js
@@ -1,0 +1,49 @@
+import migrationRunner from "node-pg-migrate";
+import { resolve } from "node:path";
+import database from "infra/database.js";
+
+const defaultMigrationOptions = {
+  dryRun: true,
+  dir: resolve("infra", "migrations"),
+  direction: "up",
+  verbose: true,
+  migrationsTable: "pgmigrations",
+};
+
+async function listPendingMigrations() {
+  let dbClient;
+  try {
+    dbClient = await database.getNewClient();
+    const pendingMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+    });
+    return pendingMigrations;
+  } finally {
+    await dbClient?.end();
+  }
+}
+
+async function runPendingMigrations() {
+  let dbClient;
+  try {
+    dbClient = await database.getNewClient();
+
+    const migratedMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+      dryRun: false,
+    });
+    return migratedMigrations;
+  } finally {
+    await dbClient?.end();
+  }
+}
+
+
+const migrator = {
+  listPendingMigrations,
+  runPendingMigrations,
+};
+
+export default migrator;

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,8 +1,6 @@
 import { createRouter } from "next-connect";
-import migrationRunner from "node-pg-migrate";
-import { resolve } from "node:path";
-import database from "infra/database.js";
 import controller from "infra/controller.js";
+import migrator from "models/migrator.js";
 
 const router = createRouter();
 
@@ -10,44 +8,15 @@ router.get(getHandler).post(postHandler);
 
 export default router.handler(controller.errorHandlers);
 
-const defaultMigrationOptions = {
-  dryRun: true,
-  dir: resolve("infra", "migrations"),
-  direction: "up",
-  verbose: true,
-  migrationsTable: "pgmigrations",
-};
-
 async function getHandler(request, response) {
-  let dbClient;
-  try {
-    dbClient = await database.getNewClient();
-    const pendingMigrations = await migrationRunner({
-      ...defaultMigrationOptions,
-      dbClient,
-    });
-    return response.status(200).json(pendingMigrations);
-  } finally {
-    await dbClient.end();
-  }
+  const pendingMigrations = await migrator.listPendingMigrations();
+  return response.status(200).json(pendingMigrations);
 }
 
 async function postHandler(request, response) {
-  let dbClient;
-  try {
-    dbClient = await database.getNewClient();
-
-    const migratedMigrations = await migrationRunner({
-      ...defaultMigrationOptions,
-      dbClient,
-      dryRun: false,
-    });
-
-    if (migratedMigrations.length > 0) {
-      return response.status(201).json(migratedMigrations);
-    }
-    return response.status(200).json(migratedMigrations);
-  } finally {
-    await dbClient.end();
+  const migratedMigrations = await migrator.runPendingMigrations();
+  if (migratedMigrations.length > 0) {
+    return response.status(201).json(migratedMigrations);
   }
+  return response.status(200).json(migratedMigrations);
 }


### PR DESCRIPTION
This pull request refactors the migration logic by extracting it into a dedicated module and updating the API route to use this new abstraction. This change improves code organization, reusability, and maintainability by separating migration concerns from the API handler logic.

**Migration logic refactor:**

* Created a new `migrator` module in `models/migrator.js` that encapsulates the logic for listing and running pending migrations, handling database client management internally.

**API route simplification:**

* Updated `pages/api/v1/migrations/index.js` to use the new `migrator` module, removing direct usage of `node-pg-migrate` and database client management from the API handlers.